### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0.0
 author=Leonhard Stutz
 maintainer=Leonhard Stutz https://github.com/mulder-fbi/TSL45315_Arduino/issues
 sentence=Arduino library for TSL45315 sensors.
+paragraph=TSL45315 is an I2C ambient light sensor. Default device address for this library is 0x29 but can be changed in the ctor.
 category=Sensors
 url=https://github.com/mulder-fbi/TSL45315_Arduino
 architectures=*


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format